### PR TITLE
Add a tutorial notebook for the debugger, and screenshots to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # JupyterLab IDE Demo
 
-Click the following link for a demonstration of JupyterLab with IDE features.
+The demo features visual debugging using the [xeus python kernel](https://blog.jupyter.org/a-visual-debugger-for-jupyter-914e61716559), and [Language Server Protocol integration](https://github.com/krassowski/jupyterlab-lsp) (code navigation + hover suggestions + linters + autocompletion + rename).
+
+## Try it online
+
+Click the following link for a demonstration of JupyterLab with IDE features:
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/blink1073/jupyter-ide-demo/stable?urlpath=/lab/tree/index.ipynb)
 
-The demo features visual debugging using the [xeus python kernel](https://blog.jupyter.org/a-visual-debugger-for-jupyter-914e61716559), and [Language Server Protocol integration](https://github.com/krassowski/jupyterlab-lsp) (code navigation + hover suggestions + linters + autocompletion + rename).
+## Debugger
+
+![debugger](https://user-images.githubusercontent.com/591645/81320695-e2537780-9091-11ea-9da6-8dddd6937d51.png)
+
+## LSP Integration
+
+![lsp](https://user-images.githubusercontent.com/591645/81707367-e48e4b00-9470-11ea-986f-c82f127c7127.png)

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -11,8 +11,11 @@ jupyter labextension install @krassowski/jupyterlab-lsp @jupyterlab/debugger@0.2
 # Uninstall ipykernel
 pip uninstall -y ipykernel
 
-# Download LSP example notebook for ptyhon
+# Download LSP example notebook for Python
 curl -o index.ipynb https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/a39e3f7f87cec3d156fddca554ab5356840dd485/examples/Python.ipynb
+
+# Download the debugger tutorial notebook
+curl -o debugger.ipynb https://raw.githubusercontent.com/jupyterlab/debugger/dfd6bf9d51a7a0cd78ca54f4173fcf527bd4d7fd/examples/index.ipynb
 
 # Update the python notebook to use xpython
 python binder/update_python_example.py


### PR DESCRIPTION
This change adds a debugger tutorial notebook, as well as screenshots on the README to give an idea of what the features look like. 

For now the LSP notebook is still open by default. Maybe we'll want to open both notebooks in the main area, side by side or as different tabs.