### PR TITLE
update environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # runtime dependencies
-  - python >=3.7,<3.8.0a0
-  - jupyterlab >=2,<3.0.0a0
+  - python ==3.9.*
+  - jupyterlab ==3.*
   - notebook=6
   # build dependencies
   - nodejs
@@ -19,12 +19,10 @@ dependencies:
   - pip
   - pylint
   - python-language-server
-  - ujson <=1.35
+  - pyls-black
+  - pyls-isort
+  - pyls-mypy
   - ruamel_yaml
-  - pip: # not-yet-appearing-in-conda-forge
-      - pyls-black
-      - pyls-isort
-      - pyls-mypy
   # debugger dependencies
   - ptvsd
-  - xeus-python=0.7.1
+  - xeus-python ==0.12.*

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -6,10 +6,7 @@ python -m pip install jupyter_lsp
 jupyter serverextension enable --sys-prefix --py jupyter_lsp
 
 # Install jupyterlab-lsp and debugger JupyterLab extensions
-jupyter labextension install @krassowski/jupyterlab-lsp @jupyterlab/debugger@0.2.0 --debug
-
-# Uninstall ipykernel
-pip uninstall -y ipykernel
+jupyter labextension install @krassowski/jupyterlab-lsp @jupyterlab/debugger --debug
 
 # Download LSP example notebook for Python
 curl -o index.ipynb https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/a39e3f7f87cec3d156fddca554ab5356840dd485/examples/Python.ipynb

--- a/binder/update_python_example.py
+++ b/binder/update_python_example.py
@@ -1,27 +1,18 @@
 import json
+import glob
 import os
 import os.path as osp
 
 here = osp.dirname(osp.abspath(__file__))
 
-fname = osp.abspath(osp.join(here, '..', 'index.ipynb'))
+def select_xpython(fname):
+    with open(fname) as fid:
+        data = json.load(fid)
+    kernelspec = data['metadata']['kernelspec']
+    kernelspec['name'] = kernelspec['display_name'] = 'xpython'
 
-with open(fname) as fid:
-    data = json.load(fid)
+    with open(fname, 'w') as fid:
+        json.dump(data, fid)
 
-data['metadata'] = {
-  "kernelspec": {
-   "display_name": "xpython",
-   "language": "python",
-   "name": "xpython"
-  },
-  "language_info": {
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "version": "3.7.3"
-  }
- }
-
-with open(fname, 'w') as fid:
-    json.dump(data, fid)
+for fname in glob.glob(osp.join(here, os.pardir, '*.ipynb')):
+    select_xpython(fname)


### PR DESCRIPTION
- lab 3
- python 3.9
- pyls plugins now avaliable from conda
- loosen pins to avoid conflicts
- rely on metadata patches instead of ipykernel-removal to select xpython